### PR TITLE
Add employees API and UI demo with Docker Compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+SA_PASSWORD=Your_strong_password123
+ALLOWED_ORIGINS=http://localhost:3000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5080
+ConnectionStrings__Default=Server=sql;Database=EmployeesDb;User Id=sa;Password=Your_strong_password123;TrustServerCertificate=True;

--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Next.js
+.next/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,58 @@
-# Codex React App
+# Employees Demo
 
-This project was bootstrapped with **Vite** and **React** using TypeScript.
+Minimal full-stack demo for a Sovereign Cloud style environment.
 
-## Available Scripts
+## Prerequisites
 
-- `npm run dev` - start the development server
-- `npm run build` - create a production build
-- `npm run preview` - preview the production build
+- Docker Desktop
 
-After installing dependencies (`npm install`), run `npm run dev` to start the app.
+## Getting Started
+
+1. Copy `.env` with required settings:
+
+```
+SA_PASSWORD=Your_strong_password123
+ALLOWED_ORIGINS=http://localhost:3000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5080
+ConnectionStrings__Default=Server=sql;Database=EmployeesDb;User Id=sa;Password=Your_strong_password123;TrustServerCertificate=True;
+```
+
+2. Build and run:
+
+```
+docker compose up --build
+```
+
+- UI: http://localhost:3000
+- API: http://localhost:5080
+- Health: http://localhost:5080/healthz
+
+Seed data will appear on first run. Use the UI to create, edit and delete employees. Sorting and search are available.
+
+### Running locally without Docker
+
+**API**
+```
+cd employees-api
+# ensure ConnectionStrings__Default and ALLOWED_ORIGINS are set
+# dotnet restore
+# dotnet run
+```
+
+**UI**
+```
+cd employees-ui
+# npm install
+# npm run dev
+```
+
+### Reset database
+
+```
+docker compose down -v
+```
+The next `docker compose up` will recreate the database and seed data.
+
+### External SQL Server
+
+Set `ConnectionStrings__Default` to point to an external SQL Server/Azure SQL instance and rebuild the API container or run the API locally with that connection string.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.9'
+services:
+  sql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=${SA_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $$SA_PASSWORD -Q 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - sql-data:/var/opt/mssql
+    networks:
+      - demo
+  employees-api:
+    build: ./employees-api
+    depends_on:
+      sql:
+        condition: service_healthy
+    environment:
+      - ConnectionStrings__Default=${ConnectionStrings__Default}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
+    ports:
+      - "5080:8080"
+    networks:
+      - demo
+  employees-ui:
+    build: ./employees-ui
+    depends_on:
+      employees-api:
+        condition: service_started
+    environment:
+      - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+    ports:
+      - "3000:3000"
+    networks:
+      - demo
+networks:
+  demo:
+    driver: bridge
+volumes:
+  sql-data:

--- a/employees-api/Data/EmployeesDbContext.cs
+++ b/employees-api/Data/EmployeesDbContext.cs
@@ -1,0 +1,25 @@
+using EmployeesApi.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace EmployeesApi.Data;
+
+public class EmployeesDbContext : DbContext
+{
+    public EmployeesDbContext(DbContextOptions<EmployeesDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Employee> Employees => Set<Employee>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Employee>(entity =>
+        {
+            entity.Property(e => e.SSN).HasMaxLength(11).IsRequired();
+            entity.HasIndex(e => e.SSN).IsUnique();
+            entity.Property(e => e.FirstName).HasMaxLength(64).IsRequired();
+            entity.Property(e => e.LastName).HasMaxLength(64).IsRequired();
+            entity.Property(e => e.Salary).HasColumnType("decimal(18,2)");
+        });
+    }
+}

--- a/employees-api/Dockerfile
+++ b/employees-api/Dockerfile
@@ -1,0 +1,14 @@
+# build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore
+RUN dotnet publish -c Release -o /app /p:UseAppHost=false
+
+# runtime
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app ./
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "EmployeesApi.dll"]

--- a/employees-api/EmployeesApi.csproj
+++ b/employees-api/EmployeesApi.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/employees-api/Migrations/20240101000000_Initial.cs
+++ b/employees-api/Migrations/20240101000000_Initial.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EmployeesApi.Migrations
+{
+    public partial class Initial : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Employees",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SSN = table.Column<string>(type: "nvarchar(11)", maxLength: 11, nullable: false),
+                    FirstName = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    LastName = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Salary = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Employees", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Employees_SSN",
+                table: "Employees",
+                column: "SSN",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Employees");
+        }
+    }
+}

--- a/employees-api/Migrations/EmployeesDbContextModelSnapshot.cs
+++ b/employees-api/Migrations/EmployeesDbContextModelSnapshot.cs
@@ -1,0 +1,29 @@
+using EmployeesApi.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+#nullable disable
+
+namespace EmployeesApi.Migrations
+{
+    [DbContext(typeof(EmployeesDbContext))]
+    partial class EmployeesDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.0");
+
+            modelBuilder.Entity("EmployeesApi.Models.Employee", b =>
+            {
+                b.Property<int>("Id").ValueGeneratedOnAdd().HasColumnType("int");
+                b.Property<string>("SSN").IsRequired().HasMaxLength(11).HasColumnType("nvarchar(11)");
+                b.Property<string>("FirstName").IsRequired().HasMaxLength(64).HasColumnType("nvarchar(64)");
+                b.Property<string>("LastName").IsRequired().HasMaxLength(64).HasColumnType("nvarchar(64)");
+                b.Property<decimal>("Salary").HasColumnType("decimal(18,2)");
+                b.HasKey("Id");
+                b.HasIndex("SSN").IsUnique();
+                b.ToTable("Employees");
+            });
+        }
+    }
+}

--- a/employees-api/Models/Employee.cs
+++ b/employees-api/Models/Employee.cs
@@ -1,0 +1,10 @@
+namespace EmployeesApi.Models;
+
+public class Employee
+{
+    public int Id { get; set; }
+    public string SSN { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public decimal Salary { get; set; }
+}

--- a/employees-api/Program.cs
+++ b/employees-api/Program.cs
@@ -1,0 +1,106 @@
+using EmployeesApi.Data;
+using EmployeesApi.Models;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("Default")
+    ?? builder.Configuration["ConnectionStrings__Default"]
+    ?? "";
+
+builder.Services.AddDbContext<EmployeesDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+builder.Services.AddEndpointsApiExplorer();
+
+var allowedOrigins = (builder.Configuration["ALLOWED_ORIGINS"] ?? "")
+    .Split(';', ',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.WithOrigins(allowedOrigins)
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+    });
+});
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<EmployeesDbContext>();
+    db.Database.Migrate();
+    if (!db.Employees.Any())
+    {
+        db.Employees.AddRange(new[]
+        {
+            new Employee { SSN = "111-22-3333", FirstName = "John", LastName = "Doe", Salary = 50000 },
+            new Employee { SSN = "222-33-4444", FirstName = "Jane", LastName = "Smith", Salary = 60000 },
+            new Employee { SSN = "333-44-5555", FirstName = "Bob", LastName = "Johnson", Salary = 55000 },
+            new Employee { SSN = "444-55-6666", FirstName = "Alice", LastName = "Williams", Salary = 70000 },
+            new Employee { SSN = "555-66-7777", FirstName = "Tom", LastName = "Brown", Salary = 45000 }
+        });
+        db.SaveChanges();
+    }
+}
+
+app.UseCors();
+
+app.MapGet("/healthz", () => Results.Json(new { status = "ok" }));
+
+app.MapGet("/api/employees", async (EmployeesDbContext db, int page = 1, int pageSize = 50, string? sortBy = null, string dir = "asc", string? q = null) =>
+{
+    var query = db.Employees.AsQueryable();
+    if (!string.IsNullOrWhiteSpace(q))
+    {
+        query = query.Where(e => e.FirstName.Contains(q) || e.LastName.Contains(q) || e.SSN.Contains(q));
+    }
+    query = (sortBy, dir.ToLower()) switch
+    {
+        ("LastName", "desc") => query.OrderByDescending(e => e.LastName),
+        ("LastName", _) => query.OrderBy(e => e.LastName),
+        ("Salary", "desc") => query.OrderByDescending(e => e.Salary),
+        ("Salary", _) => query.OrderBy(e => e.Salary),
+        _ => query.OrderBy(e => e.Id)
+    };
+    var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+    return Results.Ok(items);
+});
+
+app.MapGet("/api/employees/{id}", async (EmployeesDbContext db, int id) =>
+{
+    var employee = await db.Employees.FindAsync(id);
+    return employee is not null ? Results.Ok(employee) : Results.NotFound();
+});
+
+app.MapPost("/api/employees", async (EmployeesDbContext db, Employee employee) =>
+{
+    db.Employees.Add(employee);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/employees/{employee.Id}", employee);
+});
+
+app.MapPut("/api/employees/{id}", async (EmployeesDbContext db, int id, Employee input) =>
+{
+    var employee = await db.Employees.FindAsync(id);
+    if (employee is null) return Results.NotFound();
+    employee.SSN = input.SSN;
+    employee.FirstName = input.FirstName;
+    employee.LastName = input.LastName;
+    employee.Salary = input.Salary;
+    await db.SaveChangesAsync();
+    return Results.NoContent();
+});
+
+app.MapDelete("/api/employees/{id}", async (EmployeesDbContext db, int id) =>
+{
+    var employee = await db.Employees.FindAsync(id);
+    if (employee is null) return Results.NotFound();
+    db.Employees.Remove(employee);
+    await db.SaveChangesAsync();
+    return Results.NoContent();
+});
+
+app.Run();

--- a/employees-api/appsettings.Docker.json
+++ b/employees-api/appsettings.Docker.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "Default": "Server=sql;Database=EmployeesDb;User Id=sa;Password=YOUR_PASSWORD;TrustServerCertificate=True;"
+  }
+}

--- a/employees-api/appsettings.json
+++ b/employees-api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "Default": "Server=(localdb)\\mssqllocaldb;Database=EmployeesDb;Trusted_Connection=True;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/employees-ui/Dockerfile
+++ b/employees-ui/Dockerfile
@@ -1,0 +1,15 @@
+# build
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# production
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/employees-ui/app/employees/[id]/page.tsx
+++ b/employees-ui/app/employees/[id]/page.tsx
@@ -1,0 +1,15 @@
+import EmployeeForm from '../../../components/EmployeeForm';
+
+export default async function EditEmployee({ params }: { params: { id: string } }) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/employees/${params.id}`, { cache: 'no-store' });
+  if (!res.ok) {
+    return <div>Not found</div>;
+  }
+  const employee = await res.json();
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Edit Employee</h1>
+      <EmployeeForm employee={employee} />
+    </div>
+  );
+}

--- a/employees-ui/app/employees/new/page.tsx
+++ b/employees-ui/app/employees/new/page.tsx
@@ -1,0 +1,10 @@
+import EmployeeForm from '../../../components/EmployeeForm';
+
+export default function NewEmployee() {
+  return (
+    <div>
+      <h1 className="text-xl mb-4">New Employee</h1>
+      <EmployeeForm />
+    </div>
+  );
+}

--- a/employees-ui/app/employees/page.tsx
+++ b/employees-ui/app/employees/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface Employee {
+  id: number;
+  ssn: string;
+  firstName: string;
+  lastName: string;
+  salary: number;
+}
+
+export default function EmployeesPage() {
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [sortBy, setSortBy] = useState('LastName');
+  const [dir, setDir] = useState<'asc' | 'desc'>('asc');
+  const [q, setQ] = useState('');
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    const t = setTimeout(() => setSearch(q), 300);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/employees?sortBy=${sortBy}&dir=${dir}&q=${encodeURIComponent(search)}`)
+      .then(r => r.json())
+      .then(setEmployees)
+      .catch(() => setEmployees([]));
+  }, [sortBy, dir, search]);
+
+  const toggleSort = (field: string) => {
+    if (sortBy === field) {
+      setDir(dir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortBy(field);
+      setDir('asc');
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between mb-4">
+        <input value={q} onChange={e => setQ(e.target.value)} placeholder="Search..." className="border p-2" />
+        <Link href="/employees/new" className="bg-blue-500 text-white px-4 py-2 rounded">New Employee</Link>
+      </div>
+      <table className="min-w-full table-auto border">
+        <thead>
+          <tr>
+            <th className="border px-2">ID</th>
+            <th className="border px-2">SSN</th>
+            <th className="border px-2">First</th>
+            <th className="border px-2 cursor-pointer" onClick={() => toggleSort('LastName')}>Last</th>
+            <th className="border px-2 cursor-pointer" onClick={() => toggleSort('Salary')}>Salary</th>
+          </tr>
+        </thead>
+        <tbody>
+          {employees.map(e => (
+            <tr key={e.id} className="hover:bg-gray-100">
+              <td className="border px-2">{e.id}</td>
+              <td className="border px-2">{e.ssn}</td>
+              <td className="border px-2">{e.firstName}</td>
+              <td className="border px-2">
+                <Link href={`/employees/${e.id}`} className="text-blue-600 underline">{e.lastName}</Link>
+              </td>
+              <td className="border px-2">{e.salary.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/employees-ui/app/globals.css
+++ b/employees-ui/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/employees-ui/app/layout.tsx
+++ b/employees-ui/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import { Toaster } from 'react-hot-toast';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Employees Demo',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="p-4">
+        <Toaster position="top-right" />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/employees-ui/app/page.tsx
+++ b/employees-ui/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/employees');
+}

--- a/employees-ui/components/EmployeeForm.tsx
+++ b/employees-ui/components/EmployeeForm.tsx
@@ -1,0 +1,85 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { z } from 'zod';
+import toast from 'react-hot-toast';
+
+const schema = z.object({
+  ssn: z.string().length(11, 'SSN must be 11 characters'),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  salary: z.number().min(0),
+});
+
+type Employee = {
+  id?: number;
+  ssn: string;
+  firstName: string;
+  lastName: string;
+  salary: number;
+};
+
+export default function EmployeeForm({ employee }: { employee?: Employee }) {
+  const [form, setForm] = useState<Employee>(employee ?? { ssn: '', firstName: '', lastName: '', salary: 0 });
+  const router = useRouter();
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = schema.safeParse({ ...form, salary: Number(form.salary) });
+    if (!parsed.success) {
+      toast.error(parsed.error.errors[0].message);
+      return;
+    }
+    const method = employee ? 'PUT' : 'POST';
+    const url = employee
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/employees/${employee.id}`
+      : `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/employees`;
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(parsed.data),
+    });
+    if (res.ok) {
+      toast.success('Saved');
+      router.push('/employees');
+    } else {
+      toast.error('Error');
+    }
+  };
+
+  const del = async () => {
+    if (!employee) return;
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/employees/${employee.id}`, { method: 'DELETE' });
+    if (res.ok) {
+      toast.success('Deleted');
+      router.push('/employees');
+    } else {
+      toast.error('Error');
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4 max-w-md">
+      <div>
+        <label className="block mb-1">SSN</label>
+        <input value={form.ssn} onChange={e => setForm({ ...form, ssn: e.target.value })} className="border p-2 w-full" required />
+      </div>
+      <div>
+        <label className="block mb-1">First Name</label>
+        <input value={form.firstName} onChange={e => setForm({ ...form, firstName: e.target.value })} className="border p-2 w-full" required />
+      </div>
+      <div>
+        <label className="block mb-1">Last Name</label>
+        <input value={form.lastName} onChange={e => setForm({ ...form, lastName: e.target.value })} className="border p-2 w-full" required />
+      </div>
+      <div>
+        <label className="block mb-1">Salary</label>
+        <input type="number" step="0.01" min="0" value={form.salary} onChange={e => setForm({ ...form, salary: parseFloat(e.target.value) })} className="border p-2 w-full" required />
+      </div>
+      <div className="flex gap-2">
+        <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">{employee ? 'Update' : 'Create'}</button>
+        {employee && <button type="button" onClick={del} className="bg-red-600 text-white px-4 py-2 rounded">Delete</button>}
+      </div>
+    </form>
+  );
+}

--- a/employees-ui/next-env.d.ts
+++ b/employees-ui/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/employees-ui/next.config.mjs
+++ b/employees-ui/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/employees-ui/package.json
+++ b/employees-ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "employees-ui",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zod": "3.22.4",
+    "react-hot-toast": "2.4.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.2",
+    "typescript": "5.2.2"
+  }
+}

--- a/employees-ui/postcss.config.js
+++ b/employees-ui/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/employees-ui/tailwind.config.ts
+++ b/employees-ui/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;

--- a/employees-ui/tsconfig.json
+++ b/employees-ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add .NET 8 employees API with EF Core, CRUD endpoints, seeding and health check
- add Next.js 14 + Tailwind UI for managing employees
- add docker compose setup with SQL Server, API and UI services

## Testing
- `dotnet build employees-api/EmployeesApi.csproj` *(fails: command not found)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896888c0188832a9f6e2e8a21a4d6bd