### PR TITLE
fix: mark layout as client component

### DIFF
--- a/employees-ui/app/layout.tsx
+++ b/employees-ui/app/layout.tsx
@@ -1,3 +1,4 @@
+'use client';
 import './globals.css';
 import { Toaster } from 'react-hot-toast';
 import type { Metadata } from 'next';


### PR DESCRIPTION
## Summary
- add missing `'use client'` directive so the layout runs in the browser

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68968fd5a058832a90db6add7e21bc12